### PR TITLE
 List Horusec installations with more details

### DIFF
--- a/api/v2alpha1/horusec_platform_types.go
+++ b/api/v2alpha1/horusec_platform_types.go
@@ -247,6 +247,7 @@ type HorusecPlatformStatus struct {
 //+kubebuilder:resource:shortName=horus
 // nolint:lll // kubebuilder tags could not be split into multiple lines.
 //+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.state",description="The status of the platform installation"
+//+kubebuilder:printcolumn:name="Reason",type="string",priority=1,JSONPath=".status.conditions[?(@.status=='False')].reason",description="It indicates the reason for a condition error"
 //+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // HorusecPlatform is the Schema for the horusecs API

--- a/config/crd/bases/install.horusec.io_horusecplatforms.yaml
+++ b/config/crd/bases/install.horusec.io_horusecplatforms.yaml
@@ -23,6 +23,11 @@ spec:
       jsonPath: .status.state
       name: Status
       type: string
+    - description: It indicates the reason for a condition error
+      jsonPath: .status.conditions[?(@.status=='False')].reason
+      name: Reason
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: horuszup/horusec-operator
-  newTag: v2.0.0
+  newTag: v2.1.0

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,6 +17,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create

--- a/controllers/horusec_platform_controller.go
+++ b/controllers/horusec_platform_controller.go
@@ -39,6 +39,7 @@ func NewHorusecPlatformReconciler(adapter HorusecPlatformAdapter, client Horusec
 //+kubebuilder:rbac:groups=install.horusec.io,resources=horusecplatforms,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=install.horusec.io,resources=horusecplatforms/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=pods/log,verbs=get
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
Added more details when listing with `-o wide` option.
For example:

```console
$ kubectl get horusecplatforms
NAME       STATUS   AGE
simplest   Error    57m
```

```console
$ kubectl get horusecplatforms -o wide
NAME       STATUS   REASON          AGE
simplest   Error    DatabaseError   57m
```