### PR TITLE
updates ingress api version (networking.k8s.io/v1beta1 -> v1)

### DIFF
--- a/internal/horusec/usecase/kubeclient.go
+++ b/internal/horusec/usecase/kubeclient.go
@@ -21,7 +21,7 @@ import (
 	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	batch "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/ZupIT/horusec-operator/api/v2alpha1"
@@ -33,7 +33,7 @@ type KubernetesClient interface {
 	UpdateHorusStatus(ctx context.Context, horus *v2alpha1.HorusecPlatform) error
 	ListAutoscalingByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]autoscaling.HorizontalPodAutoscaler, error)
 	ListDeploymentsByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]apps.Deployment, error)
-	ListIngressByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]networking.Ingress, error)
+	ListIngressByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]networkingv1.Ingress, error)
 	ListJobsByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]batch.Job, error)
 	ListPodsByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]core.Pod, error)
 	ListServiceAccountsByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]core.ServiceAccount, error)

--- a/internal/horusec/usecase/resourcebuilder.go
+++ b/internal/horusec/usecase/resourcebuilder.go
@@ -19,7 +19,7 @@ import (
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 
 	"github.com/ZupIT/horusec-operator/api/v2alpha1"
 )
@@ -27,7 +27,7 @@ import (
 type ResourceBuilder interface {
 	AutoscalingFor(resource *v2alpha1.HorusecPlatform) ([]autoscalingv2beta2.HorizontalPodAutoscaler, error)
 	DeploymentsFor(resource *v2alpha1.HorusecPlatform) ([]appsv1.Deployment, error)
-	IngressFor(resource *v2alpha1.HorusecPlatform) ([]networkingv1beta1.Ingress, error)
+	IngressFor(resource *v2alpha1.HorusecPlatform) ([]networkingv1.Ingress, error)
 	JobsFor(resource *v2alpha1.HorusecPlatform) ([]batchv1.Job, error)
 	ServiceAccountsFor(resource *v2alpha1.HorusecPlatform) ([]corev1.ServiceAccount, error)
 	ServicesFor(resource *v2alpha1.HorusecPlatform) ([]corev1.Service, error)

--- a/internal/inventory/ingress.go
+++ b/internal/inventory/ingress.go
@@ -18,14 +18,14 @@ import (
 	"fmt"
 
 	"github.com/google/go-cmp/cmp"
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ZupIT/horusec-operator/internal/k8s"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
 //nolint:gocritic, funlen // to improve in the future
-func ForIngresses(existing, desired []networkingv1beta1.Ingress) k8s.Objects {
+func ForIngresses(existing, desired []networkingv1.Ingress) k8s.Objects {
 	var update []client.Object
 	mcreate := ingressMap(desired)
 	mdelete := ingressMap(existing)
@@ -62,8 +62,8 @@ func ForIngresses(existing, desired []networkingv1beta1.Ingress) k8s.Objects {
 }
 
 //nolint:gocritic // to improve in the future
-func ingressMap(deps []networkingv1beta1.Ingress) map[string]networkingv1beta1.Ingress {
-	m := map[string]networkingv1beta1.Ingress{}
+func ingressMap(deps []networkingv1.Ingress) map[string]networkingv1.Ingress {
+	m := map[string]networkingv1.Ingress{}
 	for _, d := range deps {
 		m[fmt.Sprintf("%s.%s", d.Namespace, d.Name)] = d
 	}
@@ -71,7 +71,7 @@ func ingressMap(deps []networkingv1beta1.Ingress) map[string]networkingv1beta1.I
 }
 
 //nolint // to improve in the future
-func ingressList(m map[string]networkingv1beta1.Ingress) []client.Object {
+func ingressList(m map[string]networkingv1.Ingress) []client.Object {
 	var l []client.Object
 	for _, v := range m {
 		obj := v

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -23,7 +23,7 @@ import (
 	autoscaling "k8s.io/api/autoscaling/v2beta2"
 	batch "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networkingv1 "k8s.io/api/networking/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -130,7 +130,7 @@ func (d *Client) ListDeploymentsByOwner(ctx context.Context, owner *v2alpha1.Hor
 	return list.Items, nil
 }
 
-func (d *Client) ListIngressByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]networking.Ingress, error) {
+func (d *Client) ListIngressByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]networkingv1.Ingress, error) {
 	span, ctx := tracing.StartSpanFromContext(ctx)
 	defer span.Finish()
 
@@ -138,7 +138,7 @@ func (d *Client) ListIngressByOwner(ctx context.Context, owner *v2alpha1.Horusec
 		client.InNamespace(owner.GetNamespace()),
 		client.MatchingLabels(owner.GetDefaultLabel()),
 	}
-	list := &networking.IngressList{}
+	list := &networkingv1.IngressList{}
 	if err := d.List(ctx, list, opts...); err != nil {
 		return nil, span.HandleError(fmt.Errorf("failed to list %s ingress: %w", owner.GetName(), err))
 	}

--- a/internal/resources/ingress.go
+++ b/internal/resources/ingress.go
@@ -17,15 +17,15 @@ package resources
 import (
 	"fmt"
 
-	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/ZupIT/horusec-operator/api/v2alpha1"
 	"github.com/ZupIT/horusec-operator/internal/resources/ingress"
+	networkingv1 "k8s.io/api/networking/v1"
 )
 
-func (b *Builder) IngressFor(resource *v2alpha1.HorusecPlatform) ([]networkingv1beta1.Ingress, error) {
-	var desiredList []networkingv1beta1.Ingress
+func (b *Builder) IngressFor(resource *v2alpha1.HorusecPlatform) ([]networkingv1.Ingress, error) {
+	var desiredList []networkingv1.Ingress
 	if !resource.GetAllIngressIsDisabled() {
 		desired := ingress.NewIngress(resource)
 		if err := controllerutil.SetControllerReference(resource, &desired, b.scheme); err != nil {

--- a/test/kubernetes_client.go
+++ b/test/kubernetes_client.go
@@ -10,10 +10,10 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/apps/v1"
-	v2beta2 "k8s.io/api/autoscaling/v2beta2"
-	v10 "k8s.io/api/batch/v1"
-	v11 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/networking/v1beta1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 
 	v2alpha1 "github.com/ZupIT/horusec-operator/api/v2alpha1"
 	k8s "github.com/ZupIT/horusec-operator/internal/k8s"
@@ -57,10 +57,10 @@ func (mr *MockKubernetesClientMockRecorder) Apply(ctx, objects interface{}) *gom
 }
 
 // ListAutoscalingByOwner mocks base method.
-func (m *MockKubernetesClient) ListAutoscalingByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]v2beta2.HorizontalPodAutoscaler, error) {
+func (m *MockKubernetesClient) ListAutoscalingByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]autoscalingv2beta2.HorizontalPodAutoscaler, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListAutoscalingByOwner", ctx, owner)
-	ret0, _ := ret[0].([]v2beta2.HorizontalPodAutoscaler)
+	ret0, _ := ret[0].([]autoscalingv2beta2.HorizontalPodAutoscaler)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -87,10 +87,10 @@ func (mr *MockKubernetesClientMockRecorder) ListDeploymentsByOwner(ctx, owner in
 }
 
 // ListIngressByOwner mocks base method.
-func (m *MockKubernetesClient) ListIngressByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]v1beta1.Ingress, error) {
+func (m *MockKubernetesClient) ListIngressByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]networkingv1.Ingress, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListIngressByOwner", ctx, owner)
-	ret0, _ := ret[0].([]v1beta1.Ingress)
+	ret0, _ := ret[0].([]networkingv1.Ingress)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -102,10 +102,10 @@ func (mr *MockKubernetesClientMockRecorder) ListIngressByOwner(ctx, owner interf
 }
 
 // ListJobsByOwner mocks base method.
-func (m *MockKubernetesClient) ListJobsByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]v10.Job, error) {
+func (m *MockKubernetesClient) ListJobsByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]batchv1.Job, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListJobsByOwner", ctx, owner)
-	ret0, _ := ret[0].([]v10.Job)
+	ret0, _ := ret[0].([]batchv1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -117,10 +117,10 @@ func (mr *MockKubernetesClientMockRecorder) ListJobsByOwner(ctx, owner interface
 }
 
 // ListPodsByOwner mocks base method.
-func (m *MockKubernetesClient) ListPodsByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]v11.Pod, error) {
+func (m *MockKubernetesClient) ListPodsByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]corev1.Pod, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListPodsByOwner", ctx, owner)
-	ret0, _ := ret[0].([]v11.Pod)
+	ret0, _ := ret[0].([]corev1.Pod)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -132,10 +132,10 @@ func (mr *MockKubernetesClientMockRecorder) ListPodsByOwner(ctx, owner interface
 }
 
 // ListServiceAccountsByOwner mocks base method.
-func (m *MockKubernetesClient) ListServiceAccountsByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]v11.ServiceAccount, error) {
+func (m *MockKubernetesClient) ListServiceAccountsByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]corev1.ServiceAccount, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServiceAccountsByOwner", ctx, owner)
-	ret0, _ := ret[0].([]v11.ServiceAccount)
+	ret0, _ := ret[0].([]corev1.ServiceAccount)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -147,10 +147,10 @@ func (mr *MockKubernetesClientMockRecorder) ListServiceAccountsByOwner(ctx, owne
 }
 
 // ListServicesByOwner mocks base method.
-func (m *MockKubernetesClient) ListServicesByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]v11.Service, error) {
+func (m *MockKubernetesClient) ListServicesByOwner(ctx context.Context, owner *v2alpha1.HorusecPlatform) ([]corev1.Service, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServicesByOwner", ctx, owner)
-	ret0, _ := ret[0].([]v11.Service)
+	ret0, _ := ret[0].([]corev1.Service)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
**- What I did**
updated the ingress api version

**- How to verify it**
run the operator and deploy a platform on a cluster greater than or equal 1.19

**- Description for the changelog**
updates ingress api version to networking.k8s.io/v1 (k8s server >= v1.19)